### PR TITLE
Change import path

### DIFF
--- a/array.go
+++ b/array.go
@@ -23,7 +23,7 @@ package zap
 import (
 	"time"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 // Array constructs a field with the given key and ArrayMarshaler. It provides

--- a/array_test.go
+++ b/array_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/benchmarks/go.mod
+++ b/benchmarks/go.mod
@@ -1,16 +1,16 @@
-module go.uber.org/zap/benchmarks
+module github.com/reddit/zap/benchmarks
 
 go 1.13
 
-replace go.uber.org/zap => ../
+replace github.com/reddit/zap => ../
 
 require (
 	github.com/apex/log v1.1.1
 	github.com/go-kit/kit v0.9.0
 	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/reddit/zap v0.0.0-00010101000000-000000000000
 	github.com/rs/zerolog v1.16.0
 	github.com/sirupsen/logrus v1.4.2
 	go.uber.org/multierr v1.5.0
-	go.uber.org/zap v0.0.0-00010101000000-000000000000
 	gopkg.in/inconshreveable/log15.v2 v2.0.0-20180818164646-67afb5ed74ec
 )

--- a/benchmarks/scenario_bench_test.go
+++ b/benchmarks/scenario_bench_test.go
@@ -25,7 +25,7 @@ import (
 	"log"
 	"testing"
 
-	"go.uber.org/zap"
+	"github.com/reddit/zap"
 )
 
 func BenchmarkDisabledWithoutFields(b *testing.B) {

--- a/benchmarks/zap_test.go
+++ b/benchmarks/zap_test.go
@@ -25,10 +25,10 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/reddit/zap"
+	"github.com/reddit/zap/internal/ztest"
+	"github.com/reddit/zap/zapcore"
 	"go.uber.org/multierr"
-	"go.uber.org/zap"
-	"go.uber.org/zap/internal/ztest"
-	"go.uber.org/zap/zapcore"
 )
 
 var (

--- a/buffer/buffer.go
+++ b/buffer/buffer.go
@@ -21,7 +21,7 @@
 // Package buffer provides a thin wrapper around a byte slice. Unlike the
 // standard library's bytes.Buffer, it supports a portion of the strconv
 // package's zero-allocation formatters.
-package buffer // import "go.uber.org/zap/buffer"
+package buffer // import "github.com/reddit/zap/buffer"
 
 import (
 	"strconv"

--- a/common_test.go
+++ b/common_test.go
@@ -24,8 +24,8 @@ import (
 	"sync"
 	"testing"
 
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
+	"github.com/reddit/zap/zapcore"
+	"github.com/reddit/zap/zaptest/observer"
 )
 
 func opts(opts ...Option) []Option {

--- a/config.go
+++ b/config.go
@@ -25,7 +25,7 @@ import (
 	"sort"
 	"time"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 // SamplingConfig sets a sampling strategy for the logger. Sampling caps the

--- a/config_test.go
+++ b/config_test.go
@@ -25,10 +25,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/reddit/zap/zapcore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"go.uber.org/zap/zapcore"
 )
 
 func TestConfig(t *testing.T) {
@@ -52,7 +52,7 @@ func TestConfig(t *testing.T) {
 			expectRe: "DEBUG\tzap/config_test.go:" + `\d+` + "\tdebug\t" + `{"k": "v", "z": "zz"}` + "\n" +
 				"INFO\tzap/config_test.go:" + `\d+` + "\tinfo\t" + `{"k": "v", "z": "zz"}` + "\n" +
 				"WARN\tzap/config_test.go:" + `\d+` + "\twarn\t" + `{"k": "v", "z": "zz"}` + "\n" +
-				`go.uber.org/zap.TestConfig.\w+`,
+				`github.com/reddit/zap.TestConfig.\w+`,
 		},
 	}
 

--- a/doc.go
+++ b/doc.go
@@ -91,13 +91,13 @@
 //
 // More unusual configurations (splitting output between files, sending logs
 // to a message queue, etc.) are possible, but require direct use of
-// go.uber.org/zap/zapcore. See the package-level AdvancedConfiguration
+// github.com/reddit/zap/zapcore. See the package-level AdvancedConfiguration
 // example for sample code.
 //
 // Extending Zap
 //
 // The zap package itself is a relatively thin wrapper around the interfaces
-// in go.uber.org/zap/zapcore. Extending zap to support a new encoding (e.g.,
+// in github.com/reddit/zap/zapcore. Extending zap to support a new encoding (e.g.,
 // BSON), a new log sink (e.g., Kafka), or something more exotic (perhaps an
 // exception aggregation service, like Sentry or Rollbar) typically requires
 // implementing the zapcore.Encoder, zapcore.WriteSyncer, or zapcore.Core
@@ -110,4 +110,4 @@
 //
 // An FAQ covering everything from installation errors to design decisions is
 // available at https://github.com/uber-go/zap/blob/master/FAQ.md.
-package zap // import "go.uber.org/zap"
+package zap // import "github.com/reddit/zap"

--- a/encoder.go
+++ b/encoder.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"sync"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 var (

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -23,7 +23,7 @@ package zap
 import (
 	"testing"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/error.go
+++ b/error.go
@@ -23,7 +23,7 @@ package zap
 import (
 	"sync"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 var _errArrayElemPool = sync.Pool{New: func() interface{} {

--- a/error_test.go
+++ b/error_test.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"testing"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 
 	richErrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"

--- a/example_test.go
+++ b/example_test.go
@@ -27,8 +27,8 @@ import (
 	"os"
 	"time"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap"
+	"github.com/reddit/zap/zapcore"
 )
 
 func Example_presets() {

--- a/field.go
+++ b/field.go
@@ -25,7 +25,7 @@ import (
 	"math"
 	"time"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 // Field is an alias for Field. Aliasing this type dramatically

--- a/field_test.go
+++ b/field_test.go
@@ -28,8 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/reddit/zap/zapcore"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap/zapcore"
 )
 
 type username string

--- a/flag.go
+++ b/flag.go
@@ -23,7 +23,7 @@ package zap
 import (
 	"flag"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 // LevelFlag uses the standard library's flag.Var to declare a global flag

--- a/flag_test.go
+++ b/flag_test.go
@@ -25,7 +25,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/global.go
+++ b/global.go
@@ -27,7 +27,7 @@ import (
 	"os"
 	"sync"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 const (

--- a/global_test.go
+++ b/global_test.go
@@ -26,11 +26,11 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/internal/exit"
-	"go.uber.org/zap/internal/ztest"
+	"github.com/reddit/zap/internal/exit"
+	"github.com/reddit/zap/internal/ztest"
 
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
+	"github.com/reddit/zap/zapcore"
+	"github.com/reddit/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go.uber.org/zap
+module github.com/reddit/zap
 
 go 1.13
 

--- a/http_handler.go
+++ b/http_handler.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 // ServeHTTP is a simple JSON endpoint that can report on or change the current

--- a/http_handler_test.go
+++ b/http_handler_test.go
@@ -30,8 +30,8 @@ import (
 	"strings"
 	"testing"
 
-	. "go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	. "github.com/reddit/zap"
+	"github.com/reddit/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/increase_level_test.go
+++ b/increase_level_test.go
@@ -24,9 +24,9 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/reddit/zap/zapcore"
+	"github.com/reddit/zap/zaptest/observer"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 func newLoggedEntry(level zapcore.Level, msg string, fields ...zapcore.Field) observer.LoggedEntry {

--- a/internal/bufferpool/bufferpool.go
+++ b/internal/bufferpool/bufferpool.go
@@ -22,7 +22,7 @@
 // packages can recreate the same functionality with buffers.NewPool.
 package bufferpool
 
-import "go.uber.org/zap/buffer"
+import "github.com/reddit/zap/buffer"
 
 var (
 	_pool = buffer.NewPool()

--- a/internal/ztest/doc.go
+++ b/internal/ztest/doc.go
@@ -21,4 +21,4 @@
 // Package ztest provides low-level helpers for testing log output. These
 // utilities are helpful in zap's own unit tests, but any assertions using
 // them are strongly coupled to a single encoding.
-package ztest // import "go.uber.org/zap/internal/ztest"
+package ztest // import "github.com/reddit/zap/internal/ztest"

--- a/level.go
+++ b/level.go
@@ -21,8 +21,8 @@
 package zap
 
 import (
+	"github.com/reddit/zap/zapcore"
 	"go.uber.org/atomic"
-	"go.uber.org/zap/zapcore"
 )
 
 const (

--- a/level_test.go
+++ b/level_test.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"testing"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/logger.go
+++ b/logger.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"time"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 // A Logger provides fast, leveled, structured logging. All methods are safe

--- a/logger_bench_test.go
+++ b/logger_bench_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/internal/ztest"
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/internal/ztest"
+	"github.com/reddit/zap/zapcore"
 )
 
 type user struct {

--- a/logger_test.go
+++ b/logger_test.go
@@ -25,10 +25,10 @@ import (
 	"sync"
 	"testing"
 
-	"go.uber.org/zap/internal/exit"
-	"go.uber.org/zap/internal/ztest"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
+	"github.com/reddit/zap/internal/exit"
+	"github.com/reddit/zap/internal/ztest"
+	"github.com/reddit/zap/zapcore"
+	"github.com/reddit/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -384,8 +384,8 @@ func TestLoggerAddCallerFunction(t *testing.T) {
 		},
 		{
 			options:         opts(AddCaller()),
-			loggerFunction:  "go.uber.org/zap.infoLog",
-			sugaredFunction: "go.uber.org/zap.infoLogSugared",
+			loggerFunction:  "github.com/reddit/zap.infoLog",
+			sugaredFunction: "github.com/reddit/zap.infoLogSugared",
 		},
 		{
 			options:         opts(AddCaller(), WithCaller(false)),
@@ -394,8 +394,8 @@ func TestLoggerAddCallerFunction(t *testing.T) {
 		},
 		{
 			options:         opts(WithCaller(true)),
-			loggerFunction:  "go.uber.org/zap.infoLog",
-			sugaredFunction: "go.uber.org/zap.infoLogSugared",
+			loggerFunction:  "github.com/reddit/zap.infoLog",
+			sugaredFunction: "github.com/reddit/zap.infoLogSugared",
 		},
 		{
 			options:         opts(WithCaller(true), WithCaller(false)),
@@ -404,13 +404,13 @@ func TestLoggerAddCallerFunction(t *testing.T) {
 		},
 		{
 			options:         opts(AddCaller(), AddCallerSkip(1), AddCallerSkip(-1)),
-			loggerFunction:  "go.uber.org/zap.infoLog",
-			sugaredFunction: "go.uber.org/zap.infoLogSugared",
+			loggerFunction:  "github.com/reddit/zap.infoLog",
+			sugaredFunction: "github.com/reddit/zap.infoLogSugared",
 		},
 		{
 			options:         opts(AddCaller(), AddCallerSkip(2)),
-			loggerFunction:  "go.uber.org/zap.withLogger",
-			sugaredFunction: "go.uber.org/zap.withLogger",
+			loggerFunction:  "github.com/reddit/zap.withLogger",
+			sugaredFunction: "github.com/reddit/zap.withLogger",
 		},
 		{
 			options:         opts(AddCaller(), AddCallerSkip(2), AddCallerSkip(3)),

--- a/options.go
+++ b/options.go
@@ -23,7 +23,7 @@ package zap
 import (
 	"fmt"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 // An Option configures a Logger.

--- a/sink.go
+++ b/sink.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"sync"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 const schemeFile = "file"

--- a/sink_test.go
+++ b/sink_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 func TestRegisterSink(t *testing.T) {

--- a/stacktrace.go
+++ b/stacktrace.go
@@ -24,7 +24,7 @@ import (
 	"runtime"
 	"sync"
 
-	"go.uber.org/zap/internal/bufferpool"
+	"github.com/reddit/zap/internal/bufferpool"
 )
 
 var (

--- a/stacktrace_ext_test.go
+++ b/stacktrace_ext_test.go
@@ -31,8 +31,8 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap"
+	"github.com/reddit/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,8 +43,8 @@ import (
 // intended to match on the function name, while this is on the full output
 // which includes filenames.
 var _zapPackages = []string{
-	"go.uber.org/zap.",
-	"go.uber.org/zap/zapcore.",
+	"github.com/reddit/zap.",
+	"github.com/reddit/zap/zapcore.",
 }
 
 func TestStacktraceFiltersZapLog(t *testing.T) {
@@ -104,7 +104,7 @@ func TestStacktraceFiltersVendorZap(t *testing.T) {
 		setupSymlink(t, curFile, filepath.Join(testDir, curFile))
 
 		// Set up symlinks for zap, and for any test dependencies.
-		setupSymlink(t, zapDir, filepath.Join(vendorDir, "go.uber.org/zap"))
+		setupSymlink(t, zapDir, filepath.Join(vendorDir, "github.com/reddit/zap"))
 		for _, dep := range deps {
 			setupSymlink(t, dep.Dir, filepath.Join(vendorDir, dep.ImportPath))
 		}

--- a/stacktrace_test.go
+++ b/stacktrace_test.go
@@ -35,7 +35,7 @@ func TestTakeStacktrace(t *testing.T) {
 	assert.Contains(
 		t,
 		lines[0],
-		"go.uber.org/zap.TestTakeStacktrace",
+		"github.com/reddit/zap.TestTakeStacktrace",
 		"Expected stacktrace to start with the test.",
 	)
 }

--- a/sugar.go
+++ b/sugar.go
@@ -23,7 +23,7 @@ package zap
 import (
 	"fmt"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 
 	"go.uber.org/multierr"
 )

--- a/sugar_test.go
+++ b/sugar_test.go
@@ -23,10 +23,10 @@ package zap
 import (
 	"testing"
 
-	"go.uber.org/zap/internal/exit"
-	"go.uber.org/zap/internal/ztest"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
+	"github.com/reddit/zap/internal/exit"
+	"github.com/reddit/zap/internal/ztest"
+	"github.com/reddit/zap/zapcore"
+	"github.com/reddit/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/writer.go
+++ b/writer.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 
 	"go.uber.org/multierr"
 )

--- a/writer_test.go
+++ b/writer_test.go
@@ -31,9 +31,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/reddit/zap/zapcore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 )
 
 func TestOpenNoPaths(t *testing.T) {

--- a/zapcore/console_encoder.go
+++ b/zapcore/console_encoder.go
@@ -24,8 +24,8 @@ import (
 	"fmt"
 	"sync"
 
-	"go.uber.org/zap/buffer"
-	"go.uber.org/zap/internal/bufferpool"
+	"github.com/reddit/zap/buffer"
+	"github.com/reddit/zap/internal/bufferpool"
 )
 
 var _sliceEncoderPool = sync.Pool{

--- a/zapcore/console_encoder_bench_test.go
+++ b/zapcore/console_encoder_bench_test.go
@@ -23,7 +23,7 @@ package zapcore_test
 import (
 	"testing"
 
-	. "go.uber.org/zap/zapcore"
+	. "github.com/reddit/zap/zapcore"
 )
 
 func BenchmarkZapConsole(b *testing.B) {

--- a/zapcore/console_encoder_test.go
+++ b/zapcore/console_encoder_test.go
@@ -22,8 +22,8 @@ package zapcore_test
 import (
 	"testing"
 
+	. "github.com/reddit/zap/zapcore"
 	"github.com/stretchr/testify/assert"
-	. "go.uber.org/zap/zapcore"
 )
 
 var (

--- a/zapcore/core_test.go
+++ b/zapcore/core_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/internal/ztest"
-	. "go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/internal/ztest"
+	. "github.com/reddit/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/zapcore/doc.go
+++ b/zapcore/doc.go
@@ -21,4 +21,4 @@
 // Package zapcore defines and implements the low-level interfaces upon which
 // zap is built. By providing alternate implementations of these interfaces,
 // external packages can extend zap's capabilities.
-package zapcore // import "go.uber.org/zap/zapcore"
+package zapcore // import "github.com/reddit/zap/zapcore"

--- a/zapcore/encoder.go
+++ b/zapcore/encoder.go
@@ -24,7 +24,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"go.uber.org/zap/buffer"
+	"github.com/reddit/zap/buffer"
 )
 
 // DefaultLineEnding defines the default line ending when writing logs.

--- a/zapcore/encoder_test.go
+++ b/zapcore/encoder_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
-	. "go.uber.org/zap/zapcore"
+	. "github.com/reddit/zap/zapcore"
 )
 
 var (

--- a/zapcore/entry.go
+++ b/zapcore/entry.go
@@ -27,8 +27,8 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap/internal/bufferpool"
-	"go.uber.org/zap/internal/exit"
+	"github.com/reddit/zap/internal/bufferpool"
+	"github.com/reddit/zap/internal/exit"
 
 	"go.uber.org/multierr"
 )

--- a/zapcore/entry_test.go
+++ b/zapcore/entry_test.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"testing"
 
-	"go.uber.org/zap/internal/exit"
+	"github.com/reddit/zap/internal/exit"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/zapcore/error_test.go
+++ b/zapcore/error_test.go
@@ -29,8 +29,8 @@ import (
 	richErrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
+	. "github.com/reddit/zap/zapcore"
 	"go.uber.org/multierr"
-	. "go.uber.org/zap/zapcore"
 )
 
 type errTooManyUsers int

--- a/zapcore/field_test.go
+++ b/zapcore/field_test.go
@@ -28,10 +28,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/reddit/zap"
+	. "github.com/reddit/zap/zapcore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	. "go.uber.org/zap/zapcore"
 )
 
 type users int

--- a/zapcore/hook_test.go
+++ b/zapcore/hook_test.go
@@ -23,8 +23,8 @@ package zapcore_test
 import (
 	"testing"
 
-	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
+	. "github.com/reddit/zap/zapcore"
+	"github.com/reddit/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/zapcore/increase_level_test.go
+++ b/zapcore/increase_level_test.go
@@ -24,11 +24,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/reddit/zap"
+	. "github.com/reddit/zap/zapcore"
+	"github.com/reddit/zap/zaptest/observer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestIncreaseLevel(t *testing.T) {

--- a/zapcore/json_encoder.go
+++ b/zapcore/json_encoder.go
@@ -28,8 +28,8 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"go.uber.org/zap/buffer"
-	"go.uber.org/zap/internal/bufferpool"
+	"github.com/reddit/zap/buffer"
+	"github.com/reddit/zap/internal/bufferpool"
 )
 
 // For JSON-escaping; see jsonEncoder.safeAddString below.

--- a/zapcore/json_encoder_bench_test.go
+++ b/zapcore/json_encoder_bench_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	. "go.uber.org/zap/zapcore"
+	. "github.com/reddit/zap/zapcore"
 )
 
 func BenchmarkJSONLogMarshalerFunc(b *testing.B) {

--- a/zapcore/json_encoder_impl_test.go
+++ b/zapcore/json_encoder_impl_test.go
@@ -30,7 +30,7 @@ import (
 	"testing/quick"
 	"time"
 
-	"go.uber.org/zap/internal/bufferpool"
+	"github.com/reddit/zap/internal/bufferpool"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/multierr"

--- a/zapcore/json_encoder_test.go
+++ b/zapcore/json_encoder_test.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap"
+	"github.com/reddit/zap/zapcore"
 )
 
 // TestJSONEncodeEntry is an more "integrated" test that makes it easier to get

--- a/zapcore/level_strings.go
+++ b/zapcore/level_strings.go
@@ -20,7 +20,7 @@
 
 package zapcore
 
-import "go.uber.org/zap/internal/color"
+import "github.com/reddit/zap/internal/color"
 
 var (
 	_levelToColor = map[Level]color.Color{

--- a/zapcore/sampler_bench_test.go
+++ b/zapcore/sampler_bench_test.go
@@ -25,10 +25,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/reddit/zap/internal/ztest"
+	. "github.com/reddit/zap/zapcore"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
-	"go.uber.org/zap/internal/ztest"
-	. "go.uber.org/zap/zapcore"
 )
 
 var counterTestCases = [][]string{

--- a/zapcore/sampler_test.go
+++ b/zapcore/sampler_test.go
@@ -26,10 +26,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/reddit/zap/internal/ztest"
+	. "github.com/reddit/zap/zapcore"
+	"github.com/reddit/zap/zaptest/observer"
 	"go.uber.org/atomic"
-	"go.uber.org/zap/internal/ztest"
-	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/zapcore/tee_logger_bench_test.go
+++ b/zapcore/tee_logger_bench_test.go
@@ -23,8 +23,8 @@ package zapcore_test
 import (
 	"testing"
 
-	"go.uber.org/zap/internal/ztest"
-	. "go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/internal/ztest"
+	. "github.com/reddit/zap/zapcore"
 )
 
 func withBenchedTee(b *testing.B, f func(Core)) {

--- a/zapcore/tee_test.go
+++ b/zapcore/tee_test.go
@@ -24,9 +24,9 @@ import (
 	"errors"
 	"testing"
 
-	"go.uber.org/zap/internal/ztest"
-	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
+	"github.com/reddit/zap/internal/ztest"
+	. "github.com/reddit/zap/zapcore"
+	"github.com/reddit/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/zapcore/write_syncer_bench_test.go
+++ b/zapcore/write_syncer_bench_test.go
@@ -23,7 +23,7 @@ package zapcore
 import (
 	"testing"
 
-	"go.uber.org/zap/internal/ztest"
+	"github.com/reddit/zap/internal/ztest"
 )
 
 func BenchmarkMultiWriteSyncer(b *testing.B) {

--- a/zapcore/write_syncer_test.go
+++ b/zapcore/write_syncer_test.go
@@ -27,9 +27,9 @@ import (
 
 	"io"
 
+	"github.com/reddit/zap/internal/ztest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/internal/ztest"
 )
 
 type writeSyncSpy struct {

--- a/zapgrpc/zapgrpc.go
+++ b/zapgrpc/zapgrpc.go
@@ -19,9 +19,9 @@
 // THE SOFTWARE.
 
 // Package zapgrpc provides a logger that is compatible with grpclog.
-package zapgrpc // import "go.uber.org/zap/zapgrpc"
+package zapgrpc // import "github.com/reddit/zap/zapgrpc"
 
-import "go.uber.org/zap"
+import "github.com/reddit/zap"
 
 // An Option overrides a Logger's default configuration.
 type Option interface {

--- a/zapgrpc/zapgrpc_test.go
+++ b/zapgrpc/zapgrpc_test.go
@@ -23,9 +23,9 @@ package zapgrpc
 import (
 	"testing"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest/observer"
+	"github.com/reddit/zap"
+	"github.com/reddit/zap/zapcore"
+	"github.com/reddit/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/require"
 )

--- a/zaptest/doc.go
+++ b/zaptest/doc.go
@@ -19,4 +19,4 @@
 // THE SOFTWARE.
 
 // Package zaptest provides a variety of helpers for testing log output.
-package zaptest // import "go.uber.org/zap/zaptest"
+package zaptest // import "github.com/reddit/zap/zaptest"

--- a/zaptest/logger.go
+++ b/zaptest/logger.go
@@ -23,8 +23,8 @@ package zaptest
 import (
 	"bytes"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap"
+	"github.com/reddit/zap/zapcore"
 )
 
 // LoggerOption configures the test logger built by NewLogger.

--- a/zaptest/logger_test.go
+++ b/zaptest/logger_test.go
@@ -27,9 +27,9 @@ import (
 	"strings"
 	"testing"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/internal/ztest"
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap"
+	"github.com/reddit/zap/internal/ztest"
+	"github.com/reddit/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/zaptest/observer/logged_entry.go
+++ b/zaptest/observer/logged_entry.go
@@ -20,7 +20,7 @@
 
 package observer
 
-import "go.uber.org/zap/zapcore"
+import "github.com/reddit/zap/zapcore"
 
 // An LoggedEntry is an encoding-agnostic representation of a log message.
 // Field availability is context dependant.

--- a/zaptest/observer/logged_entry_test.go
+++ b/zaptest/observer/logged_entry_test.go
@@ -23,8 +23,8 @@ package observer
 import (
 	"testing"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap"
+	"github.com/reddit/zap/zapcore"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/zaptest/observer/observer.go
+++ b/zaptest/observer/observer.go
@@ -22,14 +22,14 @@
 // encoding-agnostic repesentation of log entries. It's useful for
 // applications that want to unit test their log output without tying their
 // tests to a particular output encoding.
-package observer // import "go.uber.org/zap/zaptest/observer"
+package observer // import "github.com/reddit/zap/zaptest/observer"
 
 import (
 	"strings"
 	"sync"
 	"time"
 
-	"go.uber.org/zap/zapcore"
+	"github.com/reddit/zap/zapcore"
 )
 
 // ObservedLogs is a concurrency-safe, ordered collection of observed logs.

--- a/zaptest/observer/observer_test.go
+++ b/zaptest/observer/observer_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
-	. "go.uber.org/zap/zaptest/observer"
+	"github.com/reddit/zap"
+	"github.com/reddit/zap/zapcore"
+	. "github.com/reddit/zap/zaptest/observer"
 )
 
 func assertEmpty(t testing.TB, logs *ObservedLogs) {

--- a/zaptest/timeout.go
+++ b/zaptest/timeout.go
@@ -23,7 +23,7 @@ package zaptest
 import (
 	"time"
 
-	"go.uber.org/zap/internal/ztest"
+	"github.com/reddit/zap/internal/ztest"
 )
 
 // Timeout scales the provided duration by $TEST_TIMEOUT_SCALE.

--- a/zaptest/timeout_test.go
+++ b/zaptest/timeout_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/reddit/zap/internal/ztest"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap/internal/ztest"
 )
 
 func TestTimeout(t *testing.T) {

--- a/zaptest/writer.go
+++ b/zaptest/writer.go
@@ -20,7 +20,7 @@
 
 package zaptest
 
-import "go.uber.org/zap/internal/ztest"
+import "github.com/reddit/zap/internal/ztest"
 
 type (
 	// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.


### PR DESCRIPTION
Just doing

    go mod edit --replace=go.uber.org/zap=github.com/reddit/zap@v1.16.1

In Baseplate.go won't cause all the go.mod files in services importing
Baseplate.go to do the same replacement, so although it works for
Baseplate.go, the service code won't build.

We have to change all the import path inside this repo into
github.com/reddit/zap so that we can change the import from
go.uber.org/zap into github.com/reddit/zap in Baseplate.go.